### PR TITLE
Fixed Marathon crash issue.

### DIFF
--- a/coreos-box/files/cloud-config.yml
+++ b/coreos-box/files/cloud-config.yml
@@ -1,4 +1,6 @@
 #cloud-config
+manage_etc_hosts: localhost
+
 coreos:
     units:
       - name: coreos-cloudinit-vagrant-mkdir.service


### PR DESCRIPTION
Using docker `host` option for network shares host networking and since `CoreOS` by default does not manage `/etc/hosts` Marathon is not able to detect hostname and it crashes.
